### PR TITLE
fix syntax error

### DIFF
--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1420,7 +1420,7 @@ def docs_python() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_python', 'build_python_docs', false)
-            if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME) {
               utils.pack_lib('python-artifacts', 'docs/_build/python-artifacts.tgz', false)
             }
           }
@@ -1438,7 +1438,7 @@ def docs_c() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', 'lib/libmxnet.so', false)
             utils.docker_run('ubuntu_cpu_c', 'build_c_docs', false)
-            if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME) {
               utils.pack_lib('c-artifacts', 'docs/_build/c-artifacts.tgz', false)
             }
           }
@@ -1456,7 +1456,7 @@ def docs_julia() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_julia', 'build_julia_docs', false)
-            if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME) {
               utils.pack_lib('julia-artifacts', 'docs/_build/julia-artifacts.tgz', false)
             }
           }
@@ -1474,7 +1474,7 @@ def docs_r() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_r', 'build_r_docs', false)
-            if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME) {
               utils.pack_lib('r-artifacts', 'docs/_build/r-artifacts.tgz', false)
             }
           }
@@ -1493,7 +1493,7 @@ def docs_scala() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_scala_docs', false)
-            if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME) {
               utils.pack_lib('scala-artifacts', 'docs/_build/scala-artifacts.tgz', false)
             }
           }
@@ -1512,7 +1512,7 @@ def docs_java() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_java_docs', false)
-            if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME) {
               utils.pack_lib('java-artifacts', 'docs/_build/java-artifacts.tgz', false)
             }
           }
@@ -1531,7 +1531,7 @@ def docs_clojure() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_clojure_docs', false)
-            if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME) {
               utils.pack_lib('clojure-artifacts', 'docs/_build/clojure-artifacts.tgz', false)
             }
           }
@@ -1549,7 +1549,7 @@ def docs_jekyll() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_cpu_jekyll', 'build_jekyll_docs', false)
-            if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME) {
               utils.pack_lib('jekyll-artifacts', 'docs/_build/jekyll-artifacts.tgz', false)
             }
           }

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1614,8 +1614,12 @@ def docs_publish() {
             // If used stashed files, you can retrieve them here
             //unstash 'full_website'
             //sh 'tar -xzf docs/_build/full_website.tgz --directory .'
-            // This jenkins job pulls artifacts from website-build-master
-            build 'restricted-website-publish-master'
+            try {
+              build 'restricted-website-publish-master'
+            }
+            catch (Exception e) {
+               println(e.getMessage())
+            }
           }
         }
       }

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1420,7 +1420,7 @@ def docs_python() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_python', 'build_python_docs', false)
-            if (env.BRANCH_NAME) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
               utils.pack_lib('python-artifacts', 'docs/_build/python-artifacts.tgz', false)
             }
           }
@@ -1438,7 +1438,7 @@ def docs_c() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', 'lib/libmxnet.so', false)
             utils.docker_run('ubuntu_cpu_c', 'build_c_docs', false)
-            if (env.BRANCH_NAME) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
               utils.pack_lib('c-artifacts', 'docs/_build/c-artifacts.tgz', false)
             }
           }
@@ -1456,7 +1456,7 @@ def docs_julia() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_julia', 'build_julia_docs', false)
-            if (env.BRANCH_NAME) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
               utils.pack_lib('julia-artifacts', 'docs/_build/julia-artifacts.tgz', false)
             }
           }
@@ -1474,7 +1474,7 @@ def docs_r() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_r', 'build_r_docs', false)
-            if (env.BRANCH_NAME) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
               utils.pack_lib('r-artifacts', 'docs/_build/r-artifacts.tgz', false)
             }
           }
@@ -1493,7 +1493,7 @@ def docs_scala() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_scala_docs', false)
-            if (env.BRANCH_NAME) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
               utils.pack_lib('scala-artifacts', 'docs/_build/scala-artifacts.tgz', false)
             }
           }
@@ -1512,7 +1512,7 @@ def docs_java() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_java_docs', false)
-            if (env.BRANCH_NAME) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
               utils.pack_lib('java-artifacts', 'docs/_build/java-artifacts.tgz', false)
             }
           }
@@ -1531,7 +1531,7 @@ def docs_clojure() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_clojure_docs', false)
-            if (env.BRANCH_NAME) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
               utils.pack_lib('clojure-artifacts', 'docs/_build/clojure-artifacts.tgz', false)
             }
           }
@@ -1549,7 +1549,7 @@ def docs_jekyll() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_cpu_jekyll', 'build_jekyll_docs', false)
-            if (env.BRANCH_NAME) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
               utils.pack_lib('jekyll-artifacts', 'docs/_build/jekyll-artifacts.tgz', false)
             }
           }

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1503,7 +1503,6 @@ def docs_scala() {
       node(NODE_LINUX_CPU) {
         ws('workspace/docs') {
           timeout(time: max_time, unit: 'MINUTES') {
-            println(should_pack_website())
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_scala_docs', false)
             if (should_pack_website()) {

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1409,6 +1409,18 @@ def compile_unix_lite() {
     }]
 }
 
+
+def should_pack_website() {
+  if (env.BRANCH_NAME) {
+    if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+      retun true
+    }
+  } else {
+    return true 
+  }
+  return false
+}
+  
 // Each of the docs_{lang} functions will build the docs...
 // Stashing is only needed for master for website publishing or for testing "new_"
 
@@ -1420,7 +1432,7 @@ def docs_python() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_python', 'build_python_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
+            if (should_pack_website()) {
               utils.pack_lib('python-artifacts', 'docs/_build/python-artifacts.tgz', false)
             }
           }
@@ -1438,7 +1450,7 @@ def docs_c() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', 'lib/libmxnet.so', false)
             utils.docker_run('ubuntu_cpu_c', 'build_c_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
+            if (should_pack_website()) {
               utils.pack_lib('c-artifacts', 'docs/_build/c-artifacts.tgz', false)
             }
           }
@@ -1456,7 +1468,7 @@ def docs_julia() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_julia', 'build_julia_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
+            if (should_pack_website()) {
               utils.pack_lib('julia-artifacts', 'docs/_build/julia-artifacts.tgz', false)
             }
           }
@@ -1474,7 +1486,7 @@ def docs_r() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_r', 'build_r_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
+            if (should_pack_website()) {
               utils.pack_lib('r-artifacts', 'docs/_build/r-artifacts.tgz', false)
             }
           }
@@ -1491,9 +1503,10 @@ def docs_scala() {
       node(NODE_LINUX_CPU) {
         ws('workspace/docs') {
           timeout(time: max_time, unit: 'MINUTES') {
+            println(should_pack_website())
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_scala_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
+            if (should_pack_website()) {
               utils.pack_lib('scala-artifacts', 'docs/_build/scala-artifacts.tgz', false)
             }
           }
@@ -1512,7 +1525,7 @@ def docs_java() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_java_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
+            if (should_pack_website()) {
               utils.pack_lib('java-artifacts', 'docs/_build/java-artifacts.tgz', false)
             }
           }
@@ -1531,7 +1544,7 @@ def docs_clojure() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_clojure_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
+            if (should_pack_website()) {
               utils.pack_lib('clojure-artifacts', 'docs/_build/clojure-artifacts.tgz', false)
             }
           }
@@ -1549,7 +1562,7 @@ def docs_jekyll() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_cpu_jekyll', 'build_jekyll_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
+            if (should_pack_website()) {
               utils.pack_lib('jekyll-artifacts', 'docs/_build/jekyll-artifacts.tgz', false)
             }
           }

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1420,7 +1420,7 @@ def docs_python() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_python', 'build_python_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
               utils.pack_lib('python-artifacts', 'docs/_build/python-artifacts.tgz', false)
             }
           }
@@ -1438,7 +1438,7 @@ def docs_c() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', 'lib/libmxnet.so', false)
             utils.docker_run('ubuntu_cpu_c', 'build_c_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
               utils.pack_lib('c-artifacts', 'docs/_build/c-artifacts.tgz', false)
             }
           }
@@ -1456,7 +1456,7 @@ def docs_julia() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_julia', 'build_julia_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
               utils.pack_lib('julia-artifacts', 'docs/_build/julia-artifacts.tgz', false)
             }
           }
@@ -1474,7 +1474,7 @@ def docs_r() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_r', 'build_r_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
               utils.pack_lib('r-artifacts', 'docs/_build/r-artifacts.tgz', false)
             }
           }
@@ -1493,7 +1493,7 @@ def docs_scala() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_scala_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
               utils.pack_lib('scala-artifacts', 'docs/_build/scala-artifacts.tgz', false)
             }
           }
@@ -1512,7 +1512,7 @@ def docs_java() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_java_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
               utils.pack_lib('java-artifacts', 'docs/_build/java-artifacts.tgz', false)
             }
           }
@@ -1531,7 +1531,7 @@ def docs_clojure() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('libmxnet', mx_lib, false)
             utils.docker_run('ubuntu_cpu_scala', 'build_clojure_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
               utils.pack_lib('clojure-artifacts', 'docs/_build/clojure-artifacts.tgz', false)
             }
           }
@@ -1549,7 +1549,7 @@ def docs_jekyll() {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_cpu_jekyll', 'build_jekyll_docs', false)
-            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_")) {
+            if (env.BRANCH_NAME && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("new_"))) {
               utils.pack_lib('jekyll-artifacts', 'docs/_build/jekyll-artifacts.tgz', false)
             }
           }


### PR DESCRIPTION
Trying to run the full website publish job... getting a syntax error. Julia finishes with success but the next line says there's an error. 

So this PR doesn't actually fix the problem... it also has all of the "true" stuff that was removed from the recent tvm release... so that could be the issue.

```
build.py: 2019-09-14 02:16:25,882Z INFO Waiting for status of container 8f91c5b79579 for 600 s.
build.py: 2019-09-14 02:16:26,218Z INFO Container exit status: {'Error': None, 'StatusCode': 0}
build.py: 2019-09-14 02:16:26,219Z INFO Container exited with success 👍
build.py: 2019-09-14 02:16:26,219Z INFO Stopping container: 8f91c5b79579
build.py: 2019-09-14 02:16:26,220Z INFO Removing container: 8f91c5b79579
build.py: 2019-09-14 02:16:26,484Z INFO Other running containers: ['c7d2857d8b66', '5ee6779b5b10']
[Pipeline] }
[Pipeline] // timeout
[Pipeline] }
[Pipeline] // ws
[Pipeline] }
[Pipeline] // node
[Pipeline] }
Failed in branch Julia Docs
[Pipeline] // parallel
[Pipeline] }
[Pipeline] // stage
[Pipeline] node
Running on utility_jaa9jjl5zq in /home/jenkins_slave/workspace/docs-pipelines/website-build-master
[Pipeline] {
[Pipeline] sh
/home/jenkins_slave/workspace/docs-pipelines/website-build-master@tmp/durable-52c4feff/script.sh: 1: /home/jenkins_slave/workspace/docs-pipelines/website-build-master@tmp/durable-52c4feff/script.sh: Syntax error: "(" unexpected
[Pipeline] }
[Pipeline] // node
[Pipeline] node
Running on utility_jaa9jjl5zq in /home/jenkins_slave/workspace/docs-pipelines/website-build-master
[Pipeline] {
[Pipeline] cleanWs
[WS-CLEANUP] Deleting project workspace...
[WS-CLEANUP] Deferred wipeout is used...
[WS-CLEANUP] done
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
ERROR: script returned exit code 2
Finished: FAILURE
```